### PR TITLE
Make kad_op_name elements const

### DIFF
--- a/kautodiff.c
+++ b/kautodiff.c
@@ -2306,7 +2306,7 @@ kad_op_f kad_op_list[KAD_MAX_OP] = {
 	kad_op_reverse     /* 36: tf.reverse, but on one axis only */
 };
 
-char *kad_op_name[KAD_MAX_OP] = {
+const char *kad_op_name[KAD_MAX_OP] = {
 	0, "add", "mul", "cmul", "ce_bin_neg", "square", "sigm", "tanh", "relu", "matmul", "avg", "1minus", "select", "ce_multi", "softmax",
 	"dropout", "conv2d", "max2d", "conv1d", "max1d", "slice", "max", "ce_bin", "sub", "sample_normal", "reduce_sum", "reduce_mean", "log",
 	"avg1d", "mse", "reshape", "concat", "stdnorm", "exp", "sin", "stack", "reverse"

--- a/kautodiff.h
+++ b/kautodiff.h
@@ -234,7 +234,7 @@ void kad_check_grad(int n, kad_node_t **a, int from);
 
 typedef int (*kad_op_f)(kad_node_t*, int);
 extern kad_op_f kad_op_list[KAD_MAX_OP];
-extern char *kad_op_name[KAD_MAX_OP];
+extern const char *kad_op_name[KAD_MAX_OP];
 
 static inline int kad_len(const kad_node_t *p) /* calculate the size of p->x */
 {


### PR DESCRIPTION
String literals are immutable (and C++ forces a diagnostic in that case).